### PR TITLE
Allow for a sorting predicate in raven-buffers-source

### DIFF
--- a/raven.el
+++ b/raven.el
@@ -426,10 +426,15 @@ INHERIT-INPUT-METHOD have the same meaning as in `completing-read'."
         (cons (kbd "M-D") 'kill-buffer)))
 
 ;;;###autoload
-(defun raven-buffers-source ()
-  "Source for open buffers."
+(defun raven-buffers-source (&optional sort-pred)
+  "Source for open buffers.
+An optional SORT-FN may be provided to sort the buffers (see
+`sort')."
   (raven-source "Buffers"
-                (mapcar 'buffer-name (buffer-list))
+                (mapcar 'buffer-name
+			(if sort-pred
+			    (sort (buffer-list) sort-pred)
+			  (buffer-list)))
                 raven-buffer-actions))
 
 ;;;###autoload


### PR DESCRIPTION
This allows for a flexible way of sorting the buffers by personal preference.
For example, I prefer sorting hidden buffers to the end of the list like so:

``` emacs-lisp
(defun th/raven-for-buffers-and-files ()
  "My `raven' interface for open buffers and files."
  (interactive)
  (raven (list (raven-buffers-source
                (lambda (a b)
                  (and (string-prefix-p " " (buffer-name b))
                       (not (string-prefix-p " " (buffer-name a))))))
               ;; more sources
               )))
```