### PR TITLE
Allow \ in input honoring its regex semantics

### DIFF
--- a/raven.el
+++ b/raven.el
@@ -45,7 +45,6 @@
 (defvar raven--result nil)
 
 (defvar raven-minibuffer-map (make-sparse-keymap))
-(define-key raven-minibuffer-map (kbd "\\") (lambda () (interactive) nil))
 (define-key raven-minibuffer-map (kbd "C-g") 'keyboard-escape-quit)
 (define-key raven-minibuffer-map (kbd "C-c") 'keyboard-escape-quit)
 (define-key raven-minibuffer-map (kbd "<return>") 'raven-do)
@@ -248,6 +247,15 @@ ACTIONS is a list of actions, which can be:
   "Draw matching candidates to minibuffer."
   (save-excursion
     (let ((pattern (raven-minibuffer-input)))
+      ;; Check if the pattern is valid.
+      (condition-case err
+	  (string-match-p pattern "")
+	(invalid-regexp
+	 ;; Nope, it's not.  Probably the used typed \ in order to fix a file
+	 ;; extension like entering raven\.el.  Print the error and simply use
+	 ;; the old pattern until it becomes valid again.
+	 (minibuffer-error-function err "" 'raven-minibuffer-render)
+	 (setq pattern raven--last)))
       (unless (string= pattern raven--last)
         (setq raven--last pattern
               raven--index 0

--- a/raven.el
+++ b/raven.el
@@ -251,7 +251,7 @@ ACTIONS is a list of actions, which can be:
       (condition-case err
 	  (string-match-p pattern "")
 	(invalid-regexp
-	 ;; Nope, it's not.  Probably the used typed \ in order to fix a file
+	 ;; Nope, it's not.  Probably the user typed \ in order to fix a file
 	 ;; extension like entering raven\.el.  Print the error and simply use
 	 ;; the old pattern until it becomes valid again.
 	 (minibuffer-error-function err "" 'raven-minibuffer-render)


### PR DESCRIPTION
Until now, typing \ as input wasn't possible.  With this PR, it is, and it
allows for entering complete regexps with grouping, or using \ in order to
escape chars with special regexp meaning.  E.g., now you can restrict to images
using an input like `\.\(jpg\|png\|gif\)$`.

If the regexp is invalid, e.g., a trailing \ or incomplete group, the error is
indicated at the end of the minibuffer prompt and matching resumes with the
last valid pattern, i.e., `raven--last`.

BTW, since I haven't said it explicitly: Raven is great! ;-)