### PR TITLE
Improve raven-source-name face

### DIFF
--- a/raven.el
+++ b/raven.el
@@ -24,9 +24,8 @@
   :group 'faces)
 
 (defface raven-source-name
-  '((t :underline t
-       :foreground "white"
-       :weight bold))
+  '((default :underline t :inherit bold)
+    (((class color) (background dark)) :foreground "white"))
   "Face used to highlight source names.")
 
 (defface raven-highlight


### PR DESCRIPTION
The :foreground used to be white on all displays which gave a nice
white-on-white with light themes.  Now it's :foreground is only forced to being
white on dark themes, and it also inherits from the bold face instead of
defining :bold t.  It's always good for a face to inherit from a standard face.
Themes usually cover most standard faces but not many faces of external
packages.


----

#